### PR TITLE
Rework data handling

### DIFF
--- a/nmrpy/data_objects.py
+++ b/nmrpy/data_objects.py
@@ -2324,7 +2324,7 @@ Ctrl+Alt+Right - assign
             "Widget for calculating concentrations is currently under heavy construction. Please calculate and assign concentrations manually."
         )
 
-    def save_to_file(self, filename=None, overwrite=False, keep_data_model=True, keep_enzymeml=True):
+    def save_to_file(self, filename=None, overwrite=False, keep_data_model=False, keep_enzymeml=True):
         """
         Save :class:`~nmrpy.data_objects.FidArray` object to file, including all objects owned.
 

--- a/nmrpy/data_objects.py
+++ b/nmrpy/data_objects.py
@@ -11,6 +11,7 @@ import os
 import pickle
 from ipywidgets import Output
 from IPython.display import display
+from datetime import datetime
 
 from nmrpy.nmrpy_model import (
     NMRpy,
@@ -230,7 +231,7 @@ class Fid(Base):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.data = kwargs.get('data', [])
-        self.raw_data = [(str(datum)) for datum in self.data]
+        self.raw_data = self.data.copy()
         self.peaks = None
         self.ranges = None
         self.species = None
@@ -2364,36 +2365,52 @@ Ctrl+Alt+Right - assign
         with open(filename, 'wb') as f:
             pickle.dump(self, f)
 
-    def save_data_model(self, format: str = "json", filename=None, overwrite=False):
+    def save_data_model(self, format: str = 'json', filename=None, overwrite=False):
         """
         Save the NMRpy data model to a file.
 
-        :keyword format: format of the file to save the data model to (default is "json")
+        :keyword format: format of the file to save the data model to (default is 'json')
 
         :keyword filename: filename to save the data model to
 
         :keyword overwrite: if True, overwrite existing file
         """
         if filename is None:
-            filename = self.fid_path + ".json"
+            basename = os.path.split(os.path.splitext(self.fid_path)[0])[-1]
+            filename = basename+'.'+format
+        if not isinstance(filename, str):
+            raise TypeError('filename must be a string.')
+        if filename[-len(format):] != format:
+            filename += '.'+format
         if not overwrite and os.path.exists(filename):
-            raise FileExistsError(f"File {filename} already exists. Set overwrite=True to force.")
+            raise FileExistsError(f'File {filename} already exists. Set overwrite=True to force.')
         
         # Convert raw_data and processed_data to lists for serialisation
         for fid in self.get_fids():
-            fid.fid_object.raw_data = fid.raw_data.tolist()
-            fid.fid_object.processed_data = fid.data.tolist()
+            # Raw data is always complex, convert to a list of strings
+            fid.fid_object.raw_data = [str(datum) for datum in fid.raw_data.copy()]
+            # If the processed data is still complex, also convert to a
+            # list of strings
+            if isinstance(fid.data.flat[0], numpy.complexfloating):
+                fid.fid_object.processed_data = [str(datum) for datum in fid.data.copy()]
+            # If the processed data is already real, convert to a list
+            # of floats instead
+            else:
+                fid.fid_object.processed_data = fid.data.tolist()
+        self.data_model.datetime_modified = datetime.now().isoformat()
 
         # Save the data model
-        if format == "json":
-            self.data_model.model_dump_json(
-                filename,
-                indent=2,
-                exclude_none=True,
-                by_alias=True
-            )
+        if format == 'json':
+            with open(filename, 'w') as f:
+                json_string = self.data_model.model_dump_json(
+                    indent=2,
+                    by_alias=True,
+                    exclude_none=True
+                )
+                f.write(json_string)
+            print(f'Data model saved to "{filename}".')
         else:
-            raise ValueError(f"Unsupported format: {format}")
+            raise ValueError(f'Unsupported format: {format}')
 
 
     def create_new_enzymeml_measurement(

--- a/nmrpy/data_objects.py
+++ b/nmrpy/data_objects.py
@@ -2328,7 +2328,7 @@ Ctrl+Alt+Right - assign
             "Widget for calculating concentrations is currently under heavy construction. Please calculate and assign concentrations manually."
         )
 
-    def save_to_file(self, filename=None, overwrite=False):
+    def save_to_file(self, filename=None, overwrite=False, keep_data_model=True, keep_enzymeml=True):
         """
         Save :class:`~nmrpy.data_objects.FidArray` object to file, including all objects owned.
 
@@ -2336,6 +2336,9 @@ Ctrl+Alt+Right - assign
 
         :keyword overwrite: if True, overwrite existing file
 
+        :keyword keep_data_model: if True, keep the NMRpy data model (default is True)
+
+        :keyword keep_enzymeml: if True, keep the EnzymeML document (default is True)
         """
         if filename is None:
             basename = os.path.split(os.path.splitext(self.fid_path)[0])[-1]
@@ -2355,6 +2358,14 @@ Ctrl+Alt+Right - assign
         self._del_widgets()
         for fid in self.get_fids():
             fid._del_widgets()
+        if not keep_data_model:
+            self.data_model = None
+            for fid in self.get_fids():
+                fid.fid_object = None
+        if not keep_enzymeml:
+            self.enzymeml_document = None
+            for fid in self.get_fids():
+                fid.enzymeml_species = None
         with open(filename, 'wb') as f:
             pickle.dump(self, f)
 

--- a/nmrpy/plotting.py
+++ b/nmrpy/plotting.py
@@ -1755,7 +1755,12 @@ class PeakAssigner:
             return
         # Check for EnzymeML document
         elif isinstance(species_source, EnzymeMLDocument):
-            self.available_species = get_species_from_enzymeml(species_source)
+            self.available_species = get_species_from_enzymeml(
+                species_source,
+                proteins=False,
+                complexes=True,
+                small_molecules=True
+            )
             return
         # Check for list of strings
         elif isinstance(species_source, list):
@@ -1919,12 +1924,20 @@ class PeakRangeAssigner:
                     "No species list provided and FIDArray has no enzymeml_document"
                 )
             self.available_species = get_species_from_enzymeml(
-                self.fid_array.enzymeml_document
+                self.fid_array.enzymeml_document,
+                proteins=False,
+                complexes=True,
+                small_molecules=True
             )
             return
         # Check for EnzymeML document
         elif isinstance(species_source, EnzymeMLDocument):
-            self.available_species = get_species_from_enzymeml(species_source)
+            self.available_species = get_species_from_enzymeml(
+                species_source,
+                proteins=False,
+                complexes=True,
+                small_molecules=True
+            )
             return
         # Check for list of strings
         elif isinstance(species_source, list):

--- a/nmrpy/utils.py
+++ b/nmrpy/utils.py
@@ -13,7 +13,12 @@ except ImportError:
 
 ##### Getters #####
 
-def get_species_from_enzymeml(enzymeml_document: EnzymeMLDocument) -> list:
+def get_species_from_enzymeml(
+    enzymeml_document: EnzymeMLDocument,
+    proteins: bool = True,
+    complexes: bool = True,
+    small_molecules: bool = True
+) -> list:
     """Iterate over various species elements in EnzymeML document,
     extract them, and return them as a list.
 
@@ -34,13 +39,20 @@ def get_species_from_enzymeml(enzymeml_document: EnzymeMLDocument) -> list:
         raise AttributeError(
             f"Parameter `enzymeml_document` has to be of type `EnzymeMLDocument`, got {type(enzymeml_document)} instead."
         )
+    if not proteins and not complexes and not small_molecules:
+        raise ValueError(
+            "At least one of the parameters `proteins`, `complexes`, or `small_molecules` must be `True`."
+        )
     available_species = []
-    for protein in enzymeml_document.proteins:
-        available_species.append(protein)
-    for complex in enzymeml_document.complexes:
-        available_species.append(complex)
-    for small_molecule in enzymeml_document.small_molecules:
-        available_species.append(small_molecule)
+    if proteins:
+        for protein in enzymeml_document.proteins:
+            available_species.append(protein)
+    if complexes:
+        for complex in enzymeml_document.complexes:
+            available_species.append(complex)
+    if small_molecules:
+        for small_molecule in enzymeml_document.small_molecules:
+            available_species.append(small_molecule)
     return available_species
 
 def get_ordered_list_of_species_names(fid: "Fid") -> list:


### PR DESCRIPTION
- When assigning species from EnzymeML to peaks using `PeakAssigner` or `PeakRangeAssigner`, proteins are now excluded from the list of selectable species. Added `proteins=True`, `complexes=True`, and `small_molecules=True` flags to the `get_species_from_enzymeml()` function to allow for more granular control over which species are pulled from EnzymeML.
- Added `keep_data_model=False` and `keep_enzymeml=True` flags to `save_to_file()` method to allow for removal of possibly storage-intensive data models.
- Changed behaviour of NMRpy data model. The rather large numpy arrays of NMR data are now converted to lists and saved to the data model only _ad hoc_ upon calling the `save_data_model()` method to save on memory size and computation time.